### PR TITLE
Review 608037-PHIAnnotationDeIdentification.md

### DIFF
--- a/wiki/608037-PHIAnnotationDeIdentification.md
+++ b/wiki/608037-PHIAnnotationDeIdentification.md
@@ -4,22 +4,22 @@
 
 ### Introduction
 
-The first series of NLP Tasks targeted by the NLP Sandbox are the annotation and de-identification of Protected Health Information (PHI) in clinical notes. This first series of tasks have been identified through our collaboration with the first NLP Sandbox Driver, the [National Center for Date to Health (CD2H)].
+The first series of NLP Sandbox tasks targeted by the NLP Sandbox are the annotation and de-identification of Protected Health Information (PHI) in clinical notes. This first series of tasks have been identified through our collaboration with the first NLP Sandbox collaborator, the [National Center for Date to Health (CD2H)].
 
-This page lists the NLP Tasks that are open for benchmarking. Each Task provides the information required to develop and benchmark an NLP Tool that meet the specification of the task.
+This page lists the NLP Sandbox tasks that are open for benchmarking. Each task provides the information required to develop and benchmark an NLP Sandbox tool that meet the specification of the task.
 
 ### NLP Sandbox PHI Deidentifier
 
-The [NLP Sandbox PHI Deidentifier] illustrates the modular design of the NLP Sandbox Tools. This React web application relies on these four NPL Tools (and counting):
+The [NLP Sandbox PHI Deidentifier] illustrates the modular design of the NLP Sandbox tools. This React web application relies on these four NPL Sandbox tools:
 
 - Date Annotator
 - Person Name Annotator
 - Physical Address Annotator
 - PHI Deidentifier
 
-The PHI Deidentifier aggregates the predictions returned by the annotators and resolves potential annotation conflicts (e.g. when more the annotations predicted by more than one annotator overlap).
+The PHI Deidentifier aggregates the predictions returned by the annotators, resolves potential annotation conflicts (e.g. when more the annotations predicted by more than one annotator overlap), and de-identifies the annotated PHI in the note.
 
-When opening the [PHI Deidentifier] application, the list of NLP Tools used is displayed. Because all Date Annotators, for example, implement the same specification, it is possible to deploy the PHI Deidentifier so that it relies on another implementation of the Date Annotator API. This modularity of the NLP Tools allows us to update the PHI Deidentifier weekly to make it use the best-performing annotators to date. Therefore, the PHI Deidentifier becomes more performant as the community submit and benchmark the performance of new NLP Tools.
+When opening the [PHI Deidentifier] application, the list of NLP Sandbox tools used is displayed. Because all Date Annotators, for example, implement the same specification, it is possible to deploy the PHI Deidentifier so that it relies on another implementation of the Date Annotator API. This modularity of the NLP Sandbox tools allows us to update the PHI Deidentifier weekly to make it use the best-performing annotators to date. Therefore, the PHI Deidentifier becomes more performant as the community submit and benchmark the performance of new NLP Sandbox tools.
 
 <!-- Blue: 0273b3 -->
 
@@ -87,13 +87,13 @@ Benchmarking:
 
 The NLP Sandbox Team is still working on identifying the specification of this task.
 
-If you would like to contribute to the development of the specification of this NLP Task (input and output schemas, datasets, baseline methods):
+If you would like to contribute to the development of the specification of this NLP Sandbox task (input and output schemas, datasets, baseline methods):
 
-1. Review the [draft specification of the NLP Sandbox PHI Deidentifier API].
+1. Review the [draft specification of the NLP Sandbox PHI Deidentifier API (the PHI Deidentifier schemas can be found under `openapi/phi-deidentifier`)].
 2. Open a ticket or a Pull Request in the GitHub repository [nlpsandbox/nlpsandbox-schemas] and describe your suggestion.
 3. Join us on the [NLP Sandbox Discord Server] and post your question or suggestion to the channel `#schemas`.
 
-Target Task Opening Date: Spring 2020
+Target Task Opening Date: Spring 2021
 
 ### Evaluation
 
@@ -106,7 +106,7 @@ Target Task Opening Date: Spring 2020
 **Instance-level evaluation**: The evaluation is performed by comparing predicted and gold standard annotation instances using two modes:
 
 - **Strict mode**: A point is awarded to the NLP Annotator if the predicted and gold standard annotation match perfectly (location of the starting character and length of the annotation). If the annotator fails to predict that "Smith" is part of the gold standard annotation "John Smith", for example, then no point is awarded.
-- **Relax mode**: While the location of the starting character of the predicted and gold standard annotation must still match, the predicted length of the annotation may fall within +- 2 characters of the length of the gold standard annotation. This is to account for occurences where a human may have annotated a string like "Backer's" while others, sentient NLP Annotator included, may consider that the annotation should be limited to "Backer".
+- **Relax mode**: While the location of the starting character of the predicted and gold standard annotation must still match, the predicted length of the annotation may fall within +- 2 characters of the length of the gold standard annotation. This is to account for occurences where a human may have annotated a string like "Michael's" while others may consider that the annotation should be limited to "Michael".
 
 **Token-level evaluation**: The evaluation is performed by comparing the tokens that compose the predicted and gold standard annotation instances. Looking back at the example where an NLP Annotator captures only "John" from "John Smith", then it would be partially awarded. To get the entire point, the annotator must predict "John Smith" or "John" and "Smith".
 
@@ -145,7 +145,7 @@ These two properties are documented as part of the NLP Sandbox [TextAnnotation] 
 
 The performance of an annotator to accuratly predict the location of entities of interest (e.g., dates, person names, etc.) is evaluated by comparing the predicted [TextAnnotation] objects returned by the annotator to the gold standard annotations identified by humans.
 
-The performance metrics listed below are reported in the Leaderboards for the category "Annotation Location":
+The performance metrics listed below are reported in the leaderboards for the category "Annotation Location":
 
 - `F1 Instance Strict`: F1 score for the instance-level evaluation (strict mode).
 - `F1 Instance Relax`: F1 score for the instance-level evaluation (relax mode).
@@ -153,19 +153,19 @@ The performance metrics listed below are reported in the Leaderboards for the ca
 
 #### Annotation Location and Type Evaluation
 
-In addition for being evaluated in the caterogy "Annotation Location", an NLP Annotator is evaluated in the category "Annotation Location and Type" if
+In addition to being evaluated in the category "Annotation Location", an NLP Annotator is evaluated in the category "Annotation Location and Type" if
 
-- the NLP task defines a type for the annotation AND
+- the task defines a type for the annotation AND
 - the NLP Annotator predicts at least one annotation with a type specified AND
 - the dataset used to evaluate the annotator includes at least one gold standard annotation with a type specified.
 
-List of NLP Tasks that have an annotation type:
+List of NLP Sandbox tasks that have an annotation type:
 
 - **Physical Address Annotation**: the schema [TextPhysicalAddressAnnotation] defines the type property `addressType`.
 
-In this evaluation category, a predicted annotation is correct if 1) the annotator successfully identify the location of the gold standard annotation (strict instance-level evaluation) and 2) correctly identify the type of the annotation.
+In this evaluation category, a predicted annotation is correct if 1) the annotator successfully identifies the location of the gold standard annotation (strict instance-level evaluation) and 2) correctly identifies the type of the annotation.
 
-The performance metrics listed below are reported in the Leaderboards for the category "Annotation Location and Type":
+The performance metrics listed below are reported in the leaderboards for the category "Annotation Location and Type":
 
 - `F1 Type`: F1 score for successfully identifying the annotation location and type.
 - `Recall Type`: Recall used to compute `F1 Type`.


### PR DESCRIPTION
> and resolves potential annotation conflicts

the Deidentifier doesn't really do this, yet.

Also, I think "token" should be better defined (or at least it should be acknowledged that we have some specific/arbitrary way of defining tokens). Tokenization is not trivial!

I suggested the change of "Driver" -> "collaborator" that I did in my other pulls. We should only make this change if it is consistent across the wiki.