### PR TITLE
Update leaderboard widgets to contain Tool information

### DIFF
--- a/wiki/608039-DateAnnotationLeaderboard.md
+++ b/wiki/608039-DateAnnotationLeaderboard.md
@@ -4,14 +4,8 @@
 
 ### Annotation Location
 
-${synapsetable?query=select id as "Submission Id"%2C createdOn as "Created
-On"%2C submitterid as Submitter%2C dataset%5Fname as "Dataset Name"%2C
-dataset%5Fversion as "Dataset Version"%2C api%5Fversion as "Api Version"%2C
-location%5FF1%5Finstance%5Frelax  as "F1 Instance Relax"%2C
-location%5FF1%5Finstance%5Fstrict as "F1 Instance Strict"%2C
-location%5FF1%5Ftoken%5Fstrict as "F1 Token Strict"%2C dockerrepositoryname as
-Repository%2C dockerdigest as Digest  from  syn23747126 where evaluationid %3D
-9614652 and status %3D %27ACCEPTED%27&showquery=false}
+<!-- markdownlint-disable-next-line first-line-h1 -->
+${synapsetable?query=select id as "Submission Id"%2C createdOn as "CreatedOn"%2C submitterid as Submitter%2C dataset%5Fname as "Dataset Name"%2C dataset%5Fversion as "Dataset Version"%2C tool%5F%5Fapi%5Fversion as "Tool Api Version"%2C tool%5F%5Fname as "Tool Name"%2C tool%5F%5Furl as "Tool URL"%2C tool%5F%5Fdescription as "Tool Description"%2C tool%5F%5Flicense as "License"%2C location%5FF1%5Finstance%5Frelax  as "F1 Instance Relax"%2Clocation%5FF1%5Finstance%5Fstrict as "F1 Instance Strict"%2Clocation%5FF1%5Ftoken%5Fstrict as "F1 Token Strict"%2C dockerrepositoryname as Repository%2C dockerdigest as Digest  from  syn23747126 where evaluationid %3D9614652 and status %3D %27ACCEPTED%27&showquery=false}
 
 {column}
 {row}

--- a/wiki/608040-PersonNameAnnotationLeaderboard.md
+++ b/wiki/608040-PersonNameAnnotationLeaderboard.md
@@ -4,14 +4,8 @@
 
 ### Annotation Location
 
-${synapsetable?query=select id as "Submission Id"%2C createdOn as "Created
-On"%2C submitterid as Submitter%2C dataset%5Fname as "Dataset Name"%2C
-dataset%5Fversion as "Dataset Version"%2C api%5Fversion as "Api Version"%2C
-location%5FF1%5Finstance%5Frelax  as "F1 Instance Relax"%2C
-location%5FF1%5Finstance%5Fstrict as "F1 Instance Strict"%2C
-location%5FF1%5Ftoken%5Fstrict as "F1 Token Strict"%2C dockerrepositoryname as
-Repository%2C dockerdigest as Digest  from  syn23747126 where evaluationid %3D
-9614657 and status %3D %27ACCEPTED%27&showquery=false}
+<!-- markdownlint-disable-next-line first-line-h1 -->
+${synapsetable?query=select id as "Submission Id"%2C createdOn as "CreatedOn"%2C submitterid as Submitter%2C dataset%5Fname as "Dataset Name"%2Cdataset%5Fversion as "Dataset Version"%2C tool%5F%5Fapi%5Fversion as "Tool Api Version"%2C tool%5F%5Fname as "Tool Name"%2C tool%5F%5Furl as "Tool URL"%2C tool%5F%5Fdescription as "Tool Description"%2C tool%5F%5Flicense as "License"%2Clocation%5FF1%5Finstance%5Frelax  as "F1 Instance Relax"%2Clocation%5FF1%5Finstance%5Fstrict as "F1 Instance Strict"%2Clocation%5FF1%5Ftoken%5Fstrict as "F1 Token Strict"%2C dockerrepositoryname as Repository%2C dockerdigest as Digest  from  syn23747126 where evaluationid %3D9614657 and status %3D %27ACCEPTED%27&showquery=false}
 
 {column}
 {row}

--- a/wiki/608041-PhysicalAddressAnnotationLeaderboard.md
+++ b/wiki/608041-PhysicalAddressAnnotationLeaderboard.md
@@ -4,23 +4,13 @@
 
 ### Annotation Location and Address Type
 
-${synapsetable?query=select id as "Submission Id"%2C createdOn as "Created
-On"%2C submitterid as Submitter%2C dataset%5Fname as "Dataset Name"%2C
-dataset%5Fversion as "Dataset Version"%2C api%5Fversion as "Api Version"%2C
-type%5FF1  as "F1 Type"%2C type%5Frecall as "Recall Type"%2C type%5Fprecision as
-"Precision Type"%2C dockerrepositoryname as Repository%2C dockerdigest as Digest
-from  syn23747126 where evaluationid %3D 9614658 and status %3D
-%27ACCEPTED%27 and type%5FF1 is not null&showquery=false}
+<!-- markdownlint-disable-next-line first-line-h1 -->
+${synapsetable?query=select id as "Submission Id"%2C createdOn as "CreatedOn"%2C submitterid as Submitter%2C dataset%5Fname as "Dataset Name"%2Cdataset%5Fversion as "Dataset Version"%2C tool%5F%5Fapi%5Fversion as "Tool Api Version"%2C tool%5F%5Fname as "Tool Name"%2C tool%5F%5Furl as "Tool URL"%2C tool%5F%5Fdescription as "Tool Description"%2C tool%5F%5Flicense as "License"%2C type%5FF1  as "F1 Type"%2C type%5Frecall as "Recall Type"%2C type%5Fprecision as"Precision Type"%2C dockerrepositoryname as Repository%2C dockerdigest as Digest from  syn23747126 where evaluationid %3D 9614658 and status %3D%27ACCEPTED%27 and type%5FF1 is not null&showquery=false}
 
 ### Annotation Location
 
-${synapsetable?query=select id as "Submission Id"%2C createdOn as "Created
-On"%2C submitterid as Submitter%2C dataset%5Fname as "Dataset Name"%2C dataset%5Fversion as "Dataset Version"%2C api%5Fversion as "Api Version"%2C
-location%5FF1%5Finstance%5Frelax  as "F1 Instance Relax"%2C
-location%5FF1%5Finstance%5Fstrict as "F1 Instance Strict"%2C
-location%5FF1%5Ftoken%5Fstrict as "F1 Token Strict"%2C dockerrepositoryname as
-Repository%2C dockerdigest as Digest  from  syn23747126 where evaluationid %3D
-9614658 and status %3D %27ACCEPTED%27&showquery=false}
+<!-- markdownlint-disable-next-line first-line-h1 -->
+${synapsetable?query=select id as "Submission Id"%2C createdOn as "CreatedOn"%2C submitterid as Submitter%2C dataset%5Fname as "Dataset Name"%2C dataset%5Fversion as "Dataset Version"%2C tool%5F%5Fapi%5Fversion as "Tool Api Version"%2C tool%5F%5Fname as "Tool Name"%2C tool%5F%5Furl as "Tool URL"%2C tool%5F%5Fdescription as "Tool Description"%2C tool%5F%5Flicense as "License"%2C location%5FF1%5Finstance%5Frelax  as "F1 Instance Relax"%2Clocation%5FF1%5Finstance%5Fstrict as "F1 Instance Strict"%2Clocation%5FF1%5Ftoken%5Fstrict as "F1 Token Strict"%2C dockerrepositoryname as Repository%2C dockerdigest as Digest  from  syn23747126 where evaluationid %3D9614658 and status %3D %27ACCEPTED%27&showquery=false}
 
 {column}
 {row}

--- a/wiki/608220-DateAnnotationDashboard.md
+++ b/wiki/608220-DateAnnotationDashboard.md
@@ -4,14 +4,8 @@
 
 ### Submissions
 
-${synapsetable?query=select id as "Submission Id"%2C createdOn as "Created
-On"%2C submitterid as Submitter%2C status as Status%2C
-dataset%5Fname as "Dataset Name"%2C dataset%5Fversion as "Dataset Version"%2C
-api%5Fversion as "Api Version"%2C
-orgSagebionetworksSynapseWorkflowOrchestratorSubmissionFolder as "Submission
-Logs"%2C submission%5Ferrors as "Submission Errors"%2C dockerrepositoryname as
-Repository%2C dockerdigest as Digest  from  syn23633219 where evaluationid %3D
-9614652 and createdBy %3D CURRENT%5FUSER%28%29&showquery=false}
+<!-- markdownlint-disable-next-line first-line-h1 -->
+${synapsetable?query=select id as "Submission Id"%2C createdOn as "CreatedOn"%2C submitterid as Submitter%2C status as Status%2Cdataset%5Fname as "Dataset Name"%2C dataset%5Fversion as "Dataset Version"%2C tool%5F%5Fapi%5Fversion as "Tool Api Version"%2C tool%5F%5Fname as "Tool Name"%2C tool%5F%5Furl as "Tool URL"%2C tool%5F%5Fdescription as "Tool Description"%2C tool%5F%5Flicense as "License"%2CorgSagebionetworksSynapseWorkflowOrchestratorSubmissionFolder as "SubmissionLogs"%2C submission%5Ferrors as "Submission Errors"%2C dockerrepositoryname as Repository%2C dockerdigest as Digest  from  syn23633219 where evaluationid %3D9614652 and createdBy %3D CURRENT%5FUSER%28%29&showquery=false}
 
 {column}
 {row}

--- a/wiki/608221-PersonNameAnnotationDashboard.md
+++ b/wiki/608221-PersonNameAnnotationDashboard.md
@@ -4,14 +4,8 @@
 
 ### Submissions
 
-${synapsetable?query=select id as "Submission Id"%2C createdOn as "Created
-On"%2C submitterid as Submitter%2C status as Status%2C
-dataset%5Fname as "Dataset Name"%2C dataset%5Fversion as "Dataset Version"%2C
-api%5Fversion as "Api Version"%2C
-orgSagebionetworksSynapseWorkflowOrchestratorSubmissionFolder as "Submission
-Logs"%2C submission%5Ferrors as "Submission Errors"%2C dockerrepositoryname as
-Repository%2C dockerdigest as Digest from  syn23633219 where evaluationid %3D
-9614657 and createdBy %3D CURRENT%5FUSER%28%29&showquery=false}
+<!-- markdownlint-disable-next-line first-line-h1 -->
+${synapsetable?query=select id as "Submission Id"%2C createdOn as "CreatedOn"%2C submitterid as Submitter%2C status as Status%2Cdataset%5Fname as "Dataset Name"%2C dataset%5Fversion as "Dataset Version"%2Ctool%5F%5Fapi%5Fversion as "Tool Api Version"%2C tool%5F%5Fname as "Tool Name"%2C tool%5F%5Furl as "Tool URL"%2C tool%5F%5Fdescription as "Tool Description"%2C tool%5F%5Flicense as "License"%2CorgSagebionetworksSynapseWorkflowOrchestratorSubmissionFolder as "SubmissionLogs"%2C submission%5Ferrors as "Submission Errors"%2C dockerrepositoryname as Repository%2C dockerdigest as Digest from  syn23633219 where evaluationid %3D9614657 and createdBy %3D CURRENT%5FUSER%28%29&showquery=false}
 
 {column}
 {row}

--- a/wiki/608222-PhysicalAddressAnnotationDashboard.md
+++ b/wiki/608222-PhysicalAddressAnnotationDashboard.md
@@ -4,14 +4,8 @@
 
 ### Submissions
 
-${synapsetable?query=select id as "Submission Id"%2C createdOn as "Created
-On"%2C submitterid as Submitter%2C status as Status%2C
-dataset%5Fname as "Dataset Name"%2C dataset%5Fversion as "Dataset Version"%2C
-api%5Fversion as "Api Version"%2C
-orgSagebionetworksSynapseWorkflowOrchestratorSubmissionFolder as "Submission
-Logs"%2C submission%5Ferrors as "Submission Errors"%2C dockerrepositoryname as
-Repository%2C dockerdigest as Digest from  syn23633219 where evaluationid %3D
-9614658 and createdBy %3D CURRENT%5FUSER%28%29&showquery=false}
+<!-- markdownlint-disable-next-line first-line-h1 -->
+${synapsetable?query=select id as "Submission Id"%2C createdOn as "CreatedOn"%2C submitterid as Submitter%2C status as Status%2Cdataset%5Fname as "Dataset Name"%2C dataset%5Fversion as "Dataset Version"%2Ctool%5F%5Fapi%5Fversion as "Tool Api Version"%2C tool%5F%5Fname as "Tool Name"%2C tool%5F%5Furl as "Tool URL"%2C tool%5F%5Fdescription as "Tool Description"%2C tool%5F%5Flicense as "License"%2CorgSagebionetworksSynapseWorkflowOrchestratorSubmissionFolder as "SubmissionLogs"%2C submission%5Ferrors as "Submission Errors"%2C dockerrepositoryname as Repository%2C dockerdigest as Digest from  syn23633219 where evaluationid %3D9614658 and createdBy %3D CURRENT%5FUSER%28%29&showquery=false}
 
 {column}
 {row}


### PR DESCRIPTION
* I disabled the markdown linting for the leaderboard widgets because it is an inconvenience to have to edit the widget on Synapse everytime when the strings are merged together.
* Added tool name, url, description, license, api version to leaderboards and dashboards.  Here is an [example](https://www.synapse.org/#!Synapse:syn22277124/wiki/608039)